### PR TITLE
Add searching by supplied params

### DIFF
--- a/cads_to_scrape.json
+++ b/cads_to_scrape.json
@@ -1,6 +1,0 @@
-[
-    {
-        "mcmaster_id": "92290A013", 
-        "category": "M2_hex_socket_0.4_6"
-    }
-]

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,4 @@ dependencies:
     - undetected-chromedriver
     - webdriver-manager
     - bpy
-    - trimesh
-    - gmsh
+    - cadquery

--- a/sim/scripts/scraper.py
+++ b/sim/scripts/scraper.py
@@ -12,21 +12,22 @@ from selenium import webdriver
 from webdriver_manager.chrome import ChromeDriverManager
 from selenium.webdriver.common.by import By
 
-from utils import convert_step_to_stl
+from utils import convert_step_to_stl, McmasterSearcher, URL
+from typing import Optional
 
 
-URL = "https://www.mcmaster.com/"
 properties = {
     "Length": 'length', 
     "Thread Size": 'thread_size',
     "Thread Pitch": 'thread_pitch'
 }
 
-def create_browser(download_path: Path, delay):
+def create_browser(delay: int, download_folder_path: Optional[Path] = None):
     options = uc.ChromeOptions()
 
-    prefs = {'download.default_directory' : str(download_path)}
-    options.add_experimental_option('prefs', prefs)
+    if download_folder_path is not None:
+        prefs = {'download.default_directory' : str(download_folder_path)}
+        options.add_experimental_option('prefs', prefs)
 
     driver = uc.Chrome(
         options = options,
@@ -48,8 +49,15 @@ def download_STEP(driver):
     download = driver.find_element(By.XPATH, "//div/a/button/span")
     download.click()
 
-def convert_cad(download_folder_path: Path):
+def convert_cad(download_folder_path: Path, mcmaster_id: str):
+    """ 
+        This functionality is actually a little jank. Selenium doesn't provide a nice way to 
+        get back the downloaded file, so it's hard to determine which file in the folder is the one we want.
+        We just assume the folder only contains the one STEP file we want. It'll then convert and delete, 
+        to be ready for the next download. So the idea is you run this after every singular download
+    """
     to_convert = [file for file in os.listdir(download_folder_path) if file.endswith(".STEP")]
+    assert len(to_convert) == 1, "Found multiple STEP files in folder, read function doc for why this is wack"
     for step_file in to_convert:
         file_name = step_file.split(".")[-2]
         convert_step_to_stl(download_folder_path / step_file, download_folder_path / f"{file_name}.stl")
@@ -69,42 +77,95 @@ def generate_label(driver, label_path: Path):
             label[properties[property]] = value.replace(" ", "")
 
     logging.info(f"Creating label at: {label_path}")
-    with open(label_path, "w") as outfile:
-        json.dump(label, outfile)
+    with open(label_path, "w") as f:
+        json.dump(label, f)
 
-def fetch_cads(output_path, url=URL, cads=[], delay=20):
+def fetch_cads(output_path, url, cads=[], delay=20):
     for cad in cads:
         mcmaster_id = cad["mcmaster_id"]
         category = cad["category"]
         download_folder_path = output_path / category
 
-        driver = create_browser(download_folder_path, delay)
+        driver = create_browser(delay, download_folder_path=download_folder_path)
         driver.get(url + mcmaster_id)
 
         download_STEP(driver)
         generate_label(driver, output_path / category / f"{mcmaster_id}.json")
 
         time.sleep(1)
-        convert_cad(download_folder_path)
+        convert_cad(download_folder_path, mcmaster_id)
         driver.close()
         driver.quit
 
+def search_for(search_params_file_path: Path, search_limit: int, output_path: Path, delay=20):
+    with open(search_params_file_path) as f:
+        search_params = json.load(f)
+
+    searcher = McmasterSearcher(search_params) 
+    all_cad_ids = []
+    while not searcher.is_done():
+        for i in range(search_limit):
+            url = searcher.next()
+            driver = create_browser(delay)
+            driver.get(url)
+
+            # Pretty dumb, mcmaster carr search query params are kinda bugged, so actually 
+            # click one of the filter params twice(for no-op) so things actually filter
+            example_href = url.split("/")[-2] + "/"
+            filter_param = driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]')
+            filter_param.click()
+            time.sleep(0.5)
+            filter_param = driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]')
+            filter_param.click()
+
+            links = driver.find_elements(By.CSS_SELECTOR, "a.PartNbrLnk")
+            cad_ids = [{"mcmaster_id": link.text, "category": link.text} for link in links if link.text]
+
+            if not cad_ids:
+                logging.error(f"Could not find any fasteners under {url}")
+            else:
+                logging.info(f"Found {len(cad_ids)} under {url}")
+
+            if len(cad_ids) > search_limit:
+                logging.info(f"Pruning to {search_limit=} fasteners")
+                cad_ids = cad_ids[:search_limit]
+
+            all_cad_ids += cad_ids
+
+            driver.close()
+            driver.quit
+    
+    output_cads_json = output_path / "cads_json_from_search.json"
+    logging.info(f"Saving cads_json file scraped from searching to {output_cads_json}. So if downloading " + \
+                 "fails you can pass this file in to continue.")
+    with open(output_cads_json, "w") as f:
+        json.dump(all_cad_ids, f)
+    return output_cads_json
 
 @click.command(help="Scrape McMaster Carr for CAD models")
 @click.option("--cads_json", "cads_json", default=None, help="Input json containing cad models to pull")
+@click.option("--search_params", "search_params", default=None, help="Input json containing search params for cad models to pull")
+@click.option("--search_limit", default=1, help="Limit of cad models to pull for each category")
 @click.option("--output_path", "output_path", required=True, help="Output folder to download cad models to")
-def main(cads_json, output_path):
+def main(cads_json, search_params, search_limit, output_path):
     logging.basicConfig(level=logging.INFO)
-    cads_json_path = Path(cads_json)
-    assert cads_json_path.exists(), f"{cads_json_path} does not exist"
+    assert not (search_params and cads_json), f"'search_params' and 'cads_json' flags can't both be specified, as they are different methods of pulling models."
 
     output_path = Path(output_path)
     assert output_path.exists(), f"{output_path} does not exist"
-        
+
+    if search_params:
+        search_params_file_path = Path(search_params)
+        assert search_params_file_path.exists(), f"{search_params_file_path} does not exist"
+        cads_json = search_for(search_params_file_path, search_limit, output_path)
+    
+    cads_json_path = Path(cads_json)
+    assert cads_json_path.exists(), f"{cads_json_path} does not exist"
+
     with open(cads_json_path) as f:
         cads = json.load(f)
 
-    fetch_cads(output_path, cads=cads)
+    fetch_cads(output_path, f"{URL}/", cads=cads)
 
 if __name__ == "__main__":
     main()

--- a/sim/scripts/scraper.py
+++ b/sim/scripts/scraper.py
@@ -134,12 +134,11 @@ def search_for(search_params_file_path: Path, search_limit: int, output_path: Pa
 
             # Pretty dumb, mcmaster carr search query params are kinda bugged, so actually 
             # click one of the filter params twice(for no-op) so things actually filter
-            example_href = url.split("/")[-2] + "/"
-            filter_param = driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]')
-            click_element(driver, filter_param)
-            time.sleep(0.5)
-            filter_param = driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]')
-            click_element(driver, filter_param)
+            search_params = url.split("/")[5:]
+            example_href = search_params[-1] + "/"
+            driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]').click()
+            time.sleep(1)
+            driver.find_element(By.XPATH, '//a[@href="'+example_href+'"]').click()
 
             links = driver.find_elements(By.CSS_SELECTOR, "a.PartNbrLnk")
             cad_ids = [{"mcmaster_id": link.text, "category": link.text} for link in links if link.text]

--- a/sim/scripts/sim_runner.py
+++ b/sim/scripts/sim_runner.py
@@ -1,0 +1,65 @@
+import click
+import json
+import logging
+import os
+import subprocess
+
+from pathlib import Path
+
+@click.command(help="Run blender sim")
+@click.option("--input_folder_path", "input_folder_path", required=True, help="Input folder with donloaded CAD models")
+@click.option("--output_folder_path", "output_folder_path", required=True, help="Output folder to put generated images")
+@click.option("--copies", "copies", required=True, help="Number of copies for each fastener")
+@click.option("--batch_size", "batch_size", required=True, default=10, help="Number of models to handle at a time")
+def main(input_folder_path, output_folder_path, copies, batch_size):
+    logging.basicConfig(level=logging.INFO)
+
+    input_folder_path = Path(input_folder_path)
+    assert input_folder_path.exists(), f"{input_folder_path} does not exist"
+    output_folder_path = Path(output_folder_path)
+    assert output_folder_path.exists(), f"{output_folder_path} does not exist"
+
+    cad_models = set([d for d in os.listdir(input_folder_path) if os.path.isdir(input_folder_path / d)])
+    existing = set([d for d in os.listdir(output_folder_path) if os.path.isdir(output_folder_path / d)])
+
+    logging.info(f"{len(cad_models)} total")
+    logging.info(f"{len(existing)} existing")
+    logging.info(f"{len(cad_models - existing)} to convert")
+
+    curr_state = {
+        "remaining": list(cad_models),
+        "to_convert": [],
+        "failed": [],
+    }
+    curr_state_json_path = output_folder_path / "curr_state.json"
+
+    while curr_state["remaining"]:
+        to_pop = min(batch_size, len(curr_state["remaining"]))
+
+        curr_state["to_convert"] = curr_state["remaining"][:to_pop]
+        curr_state["remaining"] = curr_state["remaining"][to_pop:]
+
+        with open(curr_state_json_path, 'w') as f:
+            json.dump(curr_state, f)
+
+        res = subprocess.run([
+            "blender",
+            "./sim/blender_envs/screw_sorter.blend",
+            "--python",
+            "./sim/scripts/run_sim.py",
+            "--",
+            str(input_folder_path),
+            str(output_folder_path),
+            str(curr_state_json_path),
+            str(copies),
+        ])
+
+        if res.returncode:
+            logging.error(f"Errored out, adding to failed field in {str(curr_state_json_path)}")
+            curr_state["failed"] = curr_state["to_convert"]
+
+        logging.info(f"Finished with status code: {res.returncode}")
+        curr_state["to_convert"] = []
+
+if __name__ == "__main__":
+    main()

--- a/sim/scripts/utils.py
+++ b/sim/scripts/utils.py
@@ -1,7 +1,66 @@
+import itertools
+import logging
 import trimesh
+import random
 
 from pathlib import Path
+from typing import Dict
 
+URL = "https://www.mcmaster.com"
+REQUIRED_SEARCH_KEYS_SCREW = [
+    "fastener-head-type",
+    "thread-size",
+    "length",
+]
+OPTIONAL_SEARCH_KEYS_SCREW = []
+SEARCH_KEYS_SCREW = REQUIRED_SEARCH_KEYS_SCREW + OPTIONAL_SEARCH_KEYS_SCREW
+SUPPORTED_FASTENER_TYPES = ["screws"]
+
+class McmasterSearcher:
+    """
+    This will keep track of permuting through the given search params
+    """
+    def __init__(self, search_params: Dict[str, str]):
+        self.search_params = search_params
+        self.fastener_type = self.search_params.pop("fastener-type")
+        self.search_params_keys = list(self.search_params.keys())
+        self.verify_valid_search_params()
+
+        self.combinations = self.build_internal_combinations()
+        random.shuffle(self.combinations)
+
+    def verify_valid_search_params(self):
+        assert self.fastener_type in SUPPORTED_FASTENER_TYPES, f"{self.fastener_type} is not supported right now"
+
+        search_params_keys = set(self.search_params.keys())
+        assert len(search_params_keys) == len(self.search_params.keys()), "Search param keys are duplicated"
+
+        if self.fastener_type == "screws":
+            missing_required_keys = set(REQUIRED_SEARCH_KEYS_SCREW) - search_params_keys
+            assert not missing_required_keys, f"Missing search params: {missing_required_keys}"
+            
+            unsupoported_keys = search_params_keys - set(SEARCH_KEYS_SCREW)
+            assert not unsupoported_keys, f"Unsupported or misspelt search params: {unsupoported_keys}"
+
+    def build_internal_combinations(self):
+        return list(itertools.product(*list(self.search_params.values())))
+
+    def next(self):
+        if self.is_done():
+            return None
+
+        curr = self.combinations.pop()
+        url = f"{URL}/products/{self.fastener_type}"
+        for i in range(len(curr)):
+            key = self.search_params_keys[i]
+            value = curr[i]
+            url = f"{url}/{key}~{value}"
+
+        return url
+
+    def is_done(self):
+        return not self.combinations
+    
 def convert_step_to_stl(step_file_path: Path, output_file_path: Path):
     assert step_file_path.exists(), f"{step_file_path} does not exist"
     mesh = trimesh.Trimesh(

--- a/sim/scripts/utils.py
+++ b/sim/scripts/utils.py
@@ -1,6 +1,6 @@
+import cadquery as cq
 import itertools
 import logging
-import trimesh
 import random
 
 from pathlib import Path
@@ -63,16 +63,8 @@ class McmasterSearcher:
     
 def convert_step_to_stl(step_file_path: Path, output_file_path: Path):
     assert step_file_path.exists(), f"{step_file_path} does not exist"
-    mesh = trimesh.Trimesh(
-        **trimesh.interfaces.gmsh.load_gmsh(
-            file_name = str(step_file_path),
-            gmsh_args = [
-                ("Mesh.Algorithm", 6),
-                ("Mesh.CharacteristicLengthFromCurvature", 50),
-                ("General.NumThreads", 4),
-                ("Mesh.MinimumCirclePoints", 32)
-            ]
-        ))
 
-    mesh.export(str(output_file_path))
+    step_object = cq.importers.importStep(str(step_file_path))
+    cq.exporters.export(step_object, str(output_file_path))
+
     assert output_file_path.exists(), f"{output_file_path} was not successfully created, silent error somewhere"


### PR DESCRIPTION
Now supports a limited amount of search params. Can find the current supported params in `sim/scripts/utils.py`, and should be very easy to extend. Example usage is the following:
cad_search_params.json: 
```
{
    "fastener-type": "screws",
    "fastener-head-type": ["socket", "flat"],
    "thread-size": ["m3"],
    "length": ["5-mm", "6-mm"]
}
```
Command:
` python sim/scripts/scraper.py --search_params cad_search_params.json --output_path ~/tmp`

If your Mcmaster Carr wants you to login you can supply the `login` flag
` python sim/scripts/scraper.py --search_params cad_search_params.json --output_path ~/tmp --login`
