### PR TITLE
Patched HardwareSerial.h buffer from 64 -> 256

### DIFF
--- a/fw/patches/1-HardwareSerial-increase-buffer-size.patch
+++ b/fw/patches/1-HardwareSerial-increase-buffer-size.patch
@@ -1,0 +1,9 @@
+--- HardwareSerial.h    2024-03-16 10:00:00
+44c44
+<   #define SERIAL_TX_BUFFER_SIZE 64
+---
+>   #define SERIAL_TX_BUFFER_SIZE 256
+47c47
+<   #define SERIAL_RX_BUFFER_SIZE 64
+---
+>   #define SERIAL_RX_BUFFER_SIZE 256

--- a/fw/platformio.ini
+++ b/fw/platformio.ini
@@ -14,7 +14,6 @@ board = genericSTM32F103C8
 framework = arduino
 upload_protocol = serial
 extra_scripts = pre:scripts/apply_patches.py
-; upload_port = /dev/ttyUSB0
 
 lib_deps = 
     arduino-libraries/Stepper@^1.1.3

--- a/fw/platformio.ini
+++ b/fw/platformio.ini
@@ -13,7 +13,8 @@ platform = ststm32
 board = genericSTM32F103C8
 framework = arduino
 upload_protocol = serial
-upload_port = /dev/ttyUSB0
+extra_scripts = pre:scripts/apply_patches.py
+; upload_port = /dev/ttyUSB0
 
 lib_deps = 
     arduino-libraries/Stepper@^1.1.3

--- a/fw/platformio.ini
+++ b/fw/platformio.ini
@@ -14,6 +14,7 @@ board = genericSTM32F103C8
 framework = arduino
 upload_protocol = serial
 extra_scripts = pre:scripts/apply_patches.py
+upload_port = /dev/ttyUSB0 ; WINDOWS users comment this out.
 
 lib_deps = 
     arduino-libraries/Stepper@^1.1.3

--- a/fw/scripts/apply_patches.py
+++ b/fw/scripts/apply_patches.py
@@ -1,0 +1,25 @@
+# Adapted from https://docs.platformio.org/en/latest/scripting/examples/override_package_files.html
+print("apply_patches.py: Starting patching script")
+from os.path import join, isfile
+
+Import("env")
+FRAMEWORK_DIR = env.PioPlatform().get_package_dir("framework-arduinoststm32")
+patchflag_path = join(FRAMEWORK_DIR, ".patching-done")
+
+# patch file only if we didn't do it before
+if not isfile(join(FRAMEWORK_DIR, ".patching-done")):
+    print("apply_patches.py: Flag not seen, beginning patch")
+    original_file = join(FRAMEWORK_DIR, "cores", "arduino", "HardwareSerial.h")
+    patched_file = join("patches", "1-HardwareSerial-increase-buffer-size.patch")
+
+    assert isfile(original_file) and isfile(patched_file)
+
+    env.Execute("patch %s %s" % (original_file, patched_file))
+
+    def _touch(path):
+        with open(path, "w") as fp:
+            fp.write("")
+
+    env.Execute(lambda *args, **kwargs: _touch(patchflag_path))
+else:
+    print("apply_patches.py: Flag was seen, skipping patch")


### PR DESCRIPTION
Change made to solve a SW-FW comms bug.

NOTE DO NOT SEND MSGS > 256 BYTES OVER SERIAL, the Arduino Serial.h library is limited to 256 and has undefined behaviour beyond that.

Also note that one must increase the limit in src/dev/serial.h (SERIAL_MESSAGE_SIZE) as well if you're seeking to increase msg size.

As a side-effect we can autoamtically patch any dependencies following this pattern. See this linked guide. https://docs.platformio.org/en/latest/scripting/examples/override_package_files.html

