### PR TITLE
Generated a fix for xcb issue.

### DIFF
--- a/sw/ui/data_collection_backend.py
+++ b/sw/ui/data_collection_backend.py
@@ -2,6 +2,7 @@
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+import os
 import cv2
 import sys
 import shutil
@@ -113,6 +114,7 @@ class My_App(DataCollectionCoreUi):
 
 
 def start_ui(operator_name, img_dir_path):
+    os.environ["QT_QPA_PLATFORM_PLUGIN_PATH"] = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.PluginsPath)
     app = QtWidgets.QApplication([])
     myApp = My_App(operator_name, img_dir_path)
     myApp.show()


### PR DESCRIPTION
hardcode data_collection_backend.py to use the correct xcb file

Issue arises from pyqt5 finding xcb dependency within the cv2 folder instead of its own pyqt5 folder.

My old bandaid fix involved renaming
/home/screwsorter/.local/lib/python3.9/site-packages/cv2/qt/plugins/platforms to platforms_old

But that prevented usage of cv.imshow(). This new fix means we can use both cv2.imshow() and our pyqt5 application GUI.

https://stackoverflow.com/questions/68417682/qt-and-opencv-app-not-working-in-virtual-environment https://github.com/opencv/opencv-python/issues/736